### PR TITLE
[P1-001] Implement pydantic-based configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 # Example environment settings
-API_KEY=""
-DATABASE_URL=""
+# Application environment (e.g., development, test, production)
+APP_ENV="development"
+# Logging level
+LOG_LEVEL="INFO"
+# Database connection URL
+DB_URL="sqlite+aiosqlite:///./dev.db"
+# Test database connection URL
+TEST_DB_URL="sqlite+aiosqlite:///./test.db"
+# Feature flags as JSON mapping
+FEATURE_FLAGS="{}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint fmt typecheck test\:unit test\:all cov build
+.PHONY: setup lint fmt typecheck test\:unit test\:all cov build run
 
 setup:
 	pip install -r requirements-dev.txt
@@ -22,6 +22,10 @@ test\:all:
 cov:
 	PYTHONPATH=src pytest --cov=src/brandnexus --cov-report=term-missing --cov-fail-under=70
 
-
 build:
 	python -m build
+
+run:
+	APP_ENV=development \
+	DB_URL=sqlite+aiosqlite:///./dev.db \
+	PYTHONPATH=src python -m brandnexus.main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Brand Nexus"
 authors = [{ name = "Brand Nexus", email = "dev@example.com" }]
 readme = "README.md"
 requires-python = ">=3.11"
+dependencies = ["pydantic>=2.0", "pydantic-settings>=2.0"]
 
 [project.optional-dependencies]
 dev = ["ruff", "black", "mypy", "pytest", "pytest-cov", "pytest-asyncio"]
@@ -23,6 +24,7 @@ target-version = ["py311"]
 [tool.mypy]
 python_version = "3.11"
 strict = false
+plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
 addopts = "-q --cov=src/brandnexus --cov-report=term-missing --cov-fail-under=70"

--- a/src/brandnexus/config/environment.py
+++ b/src/brandnexus/config/environment.py
@@ -1,6 +1,16 @@
+from pydantic import ValidationError
+from pydantic_settings import SettingsError as PydanticSettingsError
+
 from .settings import Settings
 
 
+class EnvironmentError(Exception):
+    """Raised when environment variables are invalid."""
+
+
 def get_settings() -> Settings:
-    """Return application settings."""
-    return Settings()
+    """Load and validate application settings."""
+    try:
+        return Settings()
+    except (ValidationError, PydanticSettingsError) as exc:
+        raise EnvironmentError("Invalid environment configuration") from exc

--- a/src/brandnexus/config/settings.py
+++ b/src/brandnexus/config/settings.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    """Application settings loaded from environment."""
+    """Application settings loaded from environment variables."""
 
-    api_key: str = ""
-    database_url: str = ""
+    app_env: str = Field("development", alias="APP_ENV")
+    log_level: str = Field("INFO", alias="LOG_LEVEL")
+    db_url: str = Field("sqlite+aiosqlite:///./dev.db", alias="DB_URL")
+    test_db_url: str = Field("sqlite+aiosqlite:///./test.db", alias="TEST_DB_URL")
+    feature_flags: Dict[str, bool] = Field(default_factory=dict, alias="FEATURE_FLAGS")
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from brandnexus.config.environment import EnvironmentError, get_settings
+
+
+def test_get_settings_defaults(monkeypatch):
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.delenv("DB_URL", raising=False)
+    monkeypatch.delenv("TEST_DB_URL", raising=False)
+    monkeypatch.delenv("FEATURE_FLAGS", raising=False)
+
+    settings = get_settings()
+
+    assert settings.app_env == "development"
+    assert settings.log_level == "INFO"
+    assert settings.db_url.startswith("sqlite")
+    assert settings.test_db_url.startswith("sqlite")
+    assert settings.feature_flags == {}
+
+
+def test_get_settings_env_override(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("DB_URL", "sqlite+aiosqlite:///./custom.db")
+    monkeypatch.setenv("TEST_DB_URL", "sqlite+aiosqlite:///./custom-test.db")
+    monkeypatch.setenv("FEATURE_FLAGS", '{"new": true}')
+
+    settings = get_settings()
+
+    assert settings.app_env == "test"
+    assert settings.log_level == "DEBUG"
+    assert settings.db_url.endswith("custom.db")
+    assert settings.test_db_url.endswith("custom-test.db")
+    assert settings.feature_flags["new"] is True
+
+
+def test_invalid_feature_flags(monkeypatch):
+    monkeypatch.setenv("FEATURE_FLAGS", "invalid-json")
+
+    with pytest.raises(EnvironmentError):
+        get_settings()

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -10,5 +10,5 @@ async def test_database_and_config() -> None:
     with pytest.raises(DatabaseError):
         await connect_db("sqlite:///:memory:")
     settings = get_settings()
-    assert settings.api_key == ""
+    assert settings.db_url.startswith("sqlite")
     await main()


### PR DESCRIPTION
## Summary
- replace ad-hoc config with typed pydantic `Settings`
- add environment loader with validation and error handling
- document env vars and dev run target

## Testing
- `PYTHONPATH=src python -m brandnexus.main --help`
- `make lint`
- `make typecheck`
- `make test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6896cbd437188322bbe09fa3c3d589c5